### PR TITLE
adjust babel build to use node current

### DIFF
--- a/plugins/gatsby-source-graphcms/.babelrc
+++ b/plugins/gatsby-source-graphcms/.babelrc
@@ -5,7 +5,7 @@
       "env",
       {
         "targets": {
-          "node": 9
+          "node": "current"
         }
       }
     ]

--- a/plugins/gatsby-source-graphcms/package.json
+++ b/plugins/gatsby-source-graphcms/package.json
@@ -15,6 +15,7 @@
     "babel-cli": "^6.24.1",
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-plugin-transform-runtime": "^6.23.0",
+    "babel-preset-env": "^1.6.1",
     "jest": "^21.2.1",
     "jest-cli": "^21.2.1"
   },


### PR DESCRIPTION
per [Slack discussion](https://graphcms.slack.com/archives/C7H8AU5J4/p1510273066000144)

[Env preset · Babel](https://babeljs.io/docs/plugins/preset-env/)
> For convenience, you can use "node": "current" to only include the necessary polyfills and transforms for the Node.js version that you use to run Babel:
```
{
  "presets": [
    ["env", {
      "targets": {
        "node": "current"
      }
    }]
  ]
}
```

ran
`yarn add babel-preset-env --dev`
in
`plugins/gatsby-source-graphcms`
and changed
`9`
to
`"current"`
in
`.babelrc`

Hugo can you test and see if this works the same for you?